### PR TITLE
Strengthen against valid input causing crashes

### DIFF
--- a/bin/dockstash
+++ b/bin/dockstash
@@ -92,7 +92,7 @@ function getLogStream(host, containerId) {
 }
 
 function prepareStreamHash(host, container, logReadStream) {
-  var nameTag = container.Image.split('/')[1];
+  var nameTag = container.Image.replace(/^.*\//, '');
   var parts = nameTag.split(':');
   return {
     host: host,
@@ -167,7 +167,7 @@ function getTopMessage(status) {
 }
 
 function prepareTopHash(host, container, item, titles) {
-  var nameTag = container.Image.split('/')[1];
+  var nameTag = container.Image.replace(/^.*\//, '');
   var parts = nameTag.split(':');
   var hash = {
     host: host,

--- a/bin/dockstash
+++ b/bin/dockstash
@@ -62,7 +62,7 @@ function getContainers(host, fn) {
     url: url,
     json: true,
   }, function(err, res) {
-    fn(err, res.body);
+    fn(err, res && res.body);
   });
 }
 
@@ -75,7 +75,7 @@ function topContainer(host, containerId, fn) {
     url: url,
     json: true,
   }, function(err, res) {
-    fn(err, res.body);
+    fn(err, res && res.body);
   });
 }
 


### PR DESCRIPTION
The current code expects image names to have slashes, but 'redis:latest' and 'registry:latest' are also possible names.
Dockstash also crashes at times when there are errors returned, because it's not checking if there is a valid response.
